### PR TITLE
윈도우 환경에서만 uvloop 비활성화

### DIFF
--- a/chzzk_record.py
+++ b/chzzk_record.py
@@ -11,10 +11,12 @@ from typing import Any, Dict, List, Tuple
 import aiofiles
 import aiohttp
 import orjson
-import uvloop
 
-# Use uvloop for better performance
-uvloop.install()
+if platform.system() != "Windows":
+    import uvloop
+
+    # Use uvloop for better performance
+    uvloop.install()
 
 def setup_logger() -> logging.Logger:
     logger = logging.getLogger(__name__)

--- a/install.bat
+++ b/install.bat
@@ -34,7 +34,7 @@ REM Set the environment variable to force UTF-8 encoding
 set PYTHONUTF8=1
 
 REM Install required Python packages
-"%VENV_DIR%\Scripts\pip" install --upgrade streamlink aiohttp aiofiles orjson uvloop
+"%VENV_DIR%\Scripts\pip" install --upgrade streamlink aiohttp aiofiles orjson
 
 REM Deactivate the virtual environment
 call "%VENV_DIR%\Scripts\deactivate"


### PR DESCRIPTION
윈도우 환경에서는 uvloop 패키지를 지원하지 않기 때문에
윈도우 환경에서만 uvloop 패키지 사용을 비활성화했습니다.

![image](https://github.com/munsy0227/Chzzk-Rekoda/assets/88495487/8eb19488-4aef-4817-a2c8-c4da2843ff8f)
