### PR TITLE
Potential fix for code scanning alert no. 3: Use of insecure SSL/TLS version

### DIFF
--- a/dns_over_https.py
+++ b/dns_over_https.py
@@ -52,6 +52,11 @@ class DnsOverHttpsResolver:
         self.bootstrap_ips = self._normalize_bootstrap_ips(bootstrap_ips)
         self.timeout = timeout
         self._context = ssl.create_default_context()
+        if hasattr(self._context, "minimum_version") and hasattr(ssl, "TLSVersion"):
+            self._context.minimum_version = ssl.TLSVersion.TLSv1_2
+        else:
+            self._context.options |= getattr(ssl, "OP_NO_TLSv1", 0)
+            self._context.options |= getattr(ssl, "OP_NO_TLSv1_1", 0)
         self._cache: dict[tuple[str, int], tuple[float, tuple[str, ...]]] = {}
         self._cache_lock = threading.Lock()
 


### PR DESCRIPTION
Potential fix for [https://github.com/munsy0227/Chzzk-Rekoda/security/code-scanning/3](https://github.com/munsy0227/Chzzk-Rekoda/security/code-scanning/3)

Set an explicit minimum TLS protocol version on the `SSLContext` right after `ssl.create_default_context()` in `DnsOverHttpsResolver.__init__`.

Best fix (without changing functionality): keep using `create_default_context()` (so certificate validation and hostname checks remain intact), and add:
- `self._context.minimum_version = ssl.TLSVersion.TLSv1_2` (preferred on modern Python).
- Fallback for older runtimes: set `OP_NO_TLSv1` and `OP_NO_TLSv1_1` flags when `minimum_version`/`TLSVersion` is unavailable.

This change is confined to `dns_over_https.py` around line 54 where `_context` is initialized.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
