### PR TITLE
Fix recording stalls and add recording regression tests

### DIFF
--- a/.github/workflows/codec-smoke-test.yml
+++ b/.github/workflows/codec-smoke-test.yml
@@ -24,7 +24,6 @@ jobs:
     env:
       CHANNEL_ID: 64a90ba95d1f9feb0a798a20bbf0f40c
       DURATION_MINUTES: ${{ inputs.duration_minutes }}
-      LOG_DIR: ${{ runner.temp }}/chzzk-codec-logs
 
     steps:
       - name: Check out repository
@@ -63,6 +62,7 @@ jobs:
 
       - name: Record and verify every codec
         run: |
+          LOG_DIR="$RUNNER_TEMP/chzzk-codec-logs"
           mkdir -p "$LOG_DIR"
 
           for codec in h264 hevc av1; do

--- a/.github/workflows/codec-smoke-test.yml
+++ b/.github/workflows/codec-smoke-test.yml
@@ -143,16 +143,25 @@ jobs:
                 \( -name '*.ts' -o -name '*.mkv' -o -name '*.webm' \) \
                 -print
             } | sort | tail -n 1)"
-            actual_codec="$({
+            probe_output="$({
               ffprobe \
                 -v error \
-                -select_streams v:0 \
+                -select_streams v \
                 -show_entries stream=codec_name \
                 -of default=noprint_wrappers=1:nokey=1 \
                 "$latest_file"
             })"
+            actual_codec="$({
+              printf '%s\n' "$probe_output" \
+                | sed '/^$/d' \
+                | sort -u \
+                | paste -sd, -
+            })"
 
-            if [[ "$actual_codec" != "$expected_codec" ]]; then
+            if [[ -z "$actual_codec" ]]; then
+              echo "::error title=Missing video stream::$codec produced no video codec metadata."
+              exit 1
+            elif [[ "$actual_codec" != "$expected_codec" ]]; then
               echo "::error title=Unexpected codec::$codec produced $actual_codec instead of $expected_codec."
               exit 1
             fi

--- a/.github/workflows/codec-smoke-test.yml
+++ b/.github/workflows/codec-smoke-test.yml
@@ -1,0 +1,173 @@
+name: Codec smoke test
+
+on:
+  workflow_dispatch:
+    inputs:
+      duration_minutes:
+        description: Recording duration per codec in minutes (5-20)
+        required: true
+        default: "10"
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: chzzk-recording-integration-test
+  cancel-in-progress: false
+
+jobs:
+  record:
+    name: Record H.264, HEVC, and AV1
+    runs-on: ubuntu-24.04
+    timeout-minutes: 80
+    env:
+      CHANNEL_ID: 64a90ba95d1f9feb0a798a20bbf0f40c
+      DURATION_MINUTES: ${{ inputs.duration_minutes }}
+      LOG_DIR: ${{ runner.temp }}/chzzk-codec-logs
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          enable-cache: true
+
+      - name: Install FFmpeg and Python dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes ffmpeg
+          uv sync --locked
+          ffmpeg -hide_banner -encoders 2>/dev/null | grep -F libx265 > /dev/null
+          ffmpeg -hide_banner -encoders 2>/dev/null | grep -F libsvtav1 > /dev/null
+
+      - name: Validate test input
+        run: |
+          if [[ ! "$DURATION_MINUTES" =~ ^[0-9]+$ ]] \
+            || (( DURATION_MINUTES < 5 || DURATION_MINUTES > 20 )); then
+            echo "::error::duration_minutes must be between 5 and 20."
+            exit 1
+          fi
+
+      - name: Verify that the test channel is live
+        run: |
+          uv run --no-sync streamlink \
+            --plugin-dirs plugin \
+            --stream-url \
+            "https://chzzk.naver.com/live/$CHANNEL_ID" \
+            best > /dev/null
+
+      - name: Record and verify every codec
+        run: |
+          mkdir -p "$LOG_DIR"
+
+          for codec in h264 hevc av1; do
+            output_dir="$RUNNER_TEMP/chzzk-codec-$codec"
+            mkdir -p "$output_dir"
+
+            case "$codec" in
+              h264)
+                output_format="ts"
+                hevc_settings='{"enable": false}'
+                av1_settings='{"enable": false}'
+                expected_codec="h264"
+                ;;
+              hevc)
+                output_format="ts"
+                hevc_settings='{
+                  "enable": true,
+                  "encoder": "libx265",
+                  "bitrate": "2500k",
+                  "max_bitrate": "10000k",
+                  "preset": "ultrafast"
+                }'
+                av1_settings='{"enable": false}'
+                expected_codec="hevc"
+                ;;
+              av1)
+                output_format="mkv"
+                hevc_settings='{"enable": false}'
+                av1_settings='{
+                  "enable": true,
+                  "encoder": "libsvtav1",
+                  "bitrate": "2500k",
+                  "max_bitrate": "10000k",
+                  "preset": "13"
+                }'
+                expected_codec="av1"
+                ;;
+            esac
+
+            jq -n \
+              --arg channel_id "$CHANNEL_ID" \
+              --arg channel_name "GitHub Actions $codec codec smoke" \
+              --arg output_dir "$output_dir" \
+              --arg output_format "$output_format" \
+              --argjson hevc_settings "$hevc_settings" \
+              --argjson av1_settings "$av1_settings" \
+              '{
+                channels: [{
+                  id: $channel_id,
+                  name: $channel_name,
+                  output_dir: $output_dir,
+                  identifier: "codec_smoke",
+                  active: "on"
+                }],
+                delays: {codec_smoke: 0},
+                timeout: 30,
+                stream_segment_threads: 2,
+                output_format: $output_format,
+                recording_split_minutes: 5,
+                hevc_settings: $hevc_settings,
+                av1_settings: $av1_settings,
+                log_enabled: true,
+                cookies: {NID_SES: "", NID_AUT: ""},
+                dns_settings: {enable: false},
+                language: "en"
+              }' > config.json
+
+            : > log.log
+            bash scripts/run_long_recording_test.sh \
+              "$DURATION_MINUTES" \
+              180 \
+              "$output_dir"
+            cp log.log "$LOG_DIR/$codec.log"
+
+            latest_file="$({
+              find "$output_dir" \
+                -type f \
+                \( -name '*.ts' -o -name '*.mkv' -o -name '*.webm' \) \
+                -print
+            } | sort | tail -n 1)"
+            actual_codec="$({
+              ffprobe \
+                -v error \
+                -select_streams v:0 \
+                -show_entries stream=codec_name \
+                -of default=noprint_wrappers=1:nokey=1 \
+                "$latest_file"
+            })"
+
+            if [[ "$actual_codec" != "$expected_codec" ]]; then
+              echo "::error title=Unexpected codec::$codec produced $actual_codec instead of $expected_codec."
+              exit 1
+            fi
+
+            echo "Verified $codec output: $latest_file"
+          done
+
+      - name: Upload codec test logs
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: codec-smoke-logs-${{ github.run_id }}
+          path: |
+            ${{ runner.temp }}/chzzk-codec-logs
+            log.log
+          if-no-files-found: warn
+          retention-days: 7
+          compression-level: 9

--- a/.github/workflows/long-recording-test.yml
+++ b/.github/workflows/long-recording-test.yml
@@ -24,7 +24,6 @@ jobs:
     env:
       CHANNEL_ID: 64a90ba95d1f9feb0a798a20bbf0f40c
       DURATION_MINUTES: ${{ inputs.duration_minutes }}
-      OUTPUT_DIR: ${{ runner.temp }}/chzzk-long-recording
 
     steps:
       - name: Check out repository
@@ -45,6 +44,9 @@ jobs:
 
       - name: Configure long recording test
         run: |
+          OUTPUT_DIR="$RUNNER_TEMP/chzzk-long-recording"
+          echo "OUTPUT_DIR=$OUTPUT_DIR" >> "$GITHUB_ENV"
+
           if [[ ! "$DURATION_MINUTES" =~ ^[0-9]+$ ]] \
             || (( DURATION_MINUTES < 270 || DURATION_MINUTES > 330 )); then
             echo "::error::duration_minutes must be between 270 and 330."

--- a/.github/workflows/long-recording-test.yml
+++ b/.github/workflows/long-recording-test.yml
@@ -1,0 +1,102 @@
+name: Long recording test
+
+on:
+  workflow_dispatch:
+    inputs:
+      duration_minutes:
+        description: Recording duration in minutes (270-330)
+        required: true
+        default: "300"
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: chzzk-recording-integration-test
+  cancel-in-progress: false
+
+jobs:
+  record:
+    name: Record CHZZK stream
+    runs-on: ubuntu-24.04
+    timeout-minutes: 355
+    env:
+      CHANNEL_ID: 64a90ba95d1f9feb0a798a20bbf0f40c
+      DURATION_MINUTES: ${{ inputs.duration_minutes }}
+      OUTPUT_DIR: ${{ runner.temp }}/chzzk-long-recording
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          enable-cache: true
+
+      - name: Install FFmpeg and Python dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes ffmpeg
+          uv sync --locked
+
+      - name: Configure long recording test
+        run: |
+          if [[ ! "$DURATION_MINUTES" =~ ^[0-9]+$ ]] \
+            || (( DURATION_MINUTES < 270 || DURATION_MINUTES > 330 )); then
+            echo "::error::duration_minutes must be between 270 and 330."
+            exit 1
+          fi
+
+          mkdir -p "$OUTPUT_DIR"
+          jq -n \
+            --arg channel_id "$CHANNEL_ID" \
+            --arg output_dir "$OUTPUT_DIR" \
+            '{
+              channels: [{
+                id: $channel_id,
+                name: "GitHub Actions long recording",
+                output_dir: $output_dir,
+                identifier: "long_recording",
+                active: "on"
+              }],
+              delays: {long_recording: 0},
+              timeout: 30,
+              stream_segment_threads: 2,
+              output_format: "ts",
+              recording_split_minutes: 5,
+              hevc_settings: {enable: false},
+              av1_settings: {enable: false},
+              log_enabled: true,
+              cookies: {NID_SES: "", NID_AUT: ""},
+              dns_settings: {enable: false},
+              language: "en"
+            }' > config.json
+
+      - name: Verify that the test channel is live
+        run: |
+          uv run --no-sync streamlink \
+            --plugin-dirs plugin \
+            --stream-url \
+            "https://chzzk.naver.com/live/$CHANNEL_ID" \
+            best > /dev/null
+
+      - name: Run long recording test
+        run: |
+          bash scripts/run_long_recording_test.sh \
+            "$DURATION_MINUTES" \
+            180 \
+            "$OUTPUT_DIR"
+
+      - name: Upload recorder log
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: long-recording-log-${{ github.run_id }}
+          path: log.log
+          if-no-files-found: warn
+          retention-days: 7
+          compression-level: 9

--- a/chzzk_record.py
+++ b/chzzk_record.py
@@ -2082,7 +2082,9 @@ async def record_stream(
                             str(ffmpeg_path),
                             "--ffmpeg-copyts",
                             "--ffmpeg-start-at-zero",
-                            "--hls-segment-stream-data",
+                            # Keep segment streaming disabled so Streamlink can
+                            # retry a timed-out download before forwarding any
+                            # partial HLS data to ffmpeg.
                         ]
 
                         stream_process = await active_attempt.start_streamlink(

--- a/scripts/run_long_recording_test.sh
+++ b/scripts/run_long_recording_test.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if (( $# != 3 )); then
+    echo "Usage: $0 DURATION_MINUTES STALL_SECONDS OUTPUT_DIR" >&2
+    exit 2
+fi
+
+duration_minutes="$1"
+stall_seconds="$2"
+output_dir="$3"
+
+if [[ ! "$duration_minutes" =~ ^[0-9]+$ ]] \
+    || [[ ! "$stall_seconds" =~ ^[0-9]+$ ]] \
+    || (( duration_minutes <= 0 || stall_seconds <= 0 )); then
+    echo "Duration and stall timeout must be positive integers." >&2
+    exit 2
+fi
+
+project_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+failure_marker="$output_dir/.recording-stalled"
+duration_seconds=$((duration_minutes * 60))
+started_at=$(date +%s)
+recorder_pid=""
+monitor_pid=""
+janitor_pid=""
+
+find_recording_files() {
+    find "$output_dir" \
+        -type f \
+        \( -name '*.ts' -o -name '*.mkv' -o -name '*.webm' \) \
+        "$@"
+}
+
+stop_process() {
+    local process_id="$1"
+    if [[ -n "$process_id" ]] && kill -0 "$process_id" 2>/dev/null; then
+        kill -TERM "$process_id" 2>/dev/null || true
+        wait "$process_id" 2>/dev/null || true
+    fi
+}
+
+cleanup() {
+    stop_process "$janitor_pid"
+    stop_process "$monitor_pid"
+    stop_process "$recorder_pid"
+}
+trap cleanup EXIT
+trap 'exit 130' INT TERM
+
+cd "$project_dir"
+
+timeout \
+    --preserve-status \
+    --signal=TERM \
+    --kill-after=120s \
+    "${duration_seconds}s" \
+    uv run --no-sync python chzzk_record.py &
+recorder_pid=$!
+
+(
+    while kill -0 "$recorder_pid" 2>/dev/null; do
+        find_recording_files -mmin +15 -delete
+        sleep 60
+    done
+) &
+janitor_pid=$!
+
+(
+    while kill -0 "$recorder_pid" 2>/dev/null; do
+        latest_mtime="$({
+            find_recording_files -printf '%T@\n'
+        } | sort -nr | head -n 1)"
+        current_time=$(date +%s)
+
+        if [[ -z "$latest_mtime" ]]; then
+            inactive_seconds=$((current_time - started_at))
+        else
+            latest_mtime=${latest_mtime%%.*}
+            inactive_seconds=$((current_time - latest_mtime))
+        fi
+
+        if (( inactive_seconds > stall_seconds )); then
+            echo "::error title=Recording stalled::No recording output was written for ${inactive_seconds} seconds."
+            : > "$failure_marker"
+            kill -TERM "$recorder_pid" 2>/dev/null || true
+            exit 1
+        fi
+
+        sleep 15
+    done
+) &
+monitor_pid=$!
+
+set +e
+wait "$recorder_pid"
+recorder_status=$?
+set -e
+recorder_pid=""
+
+stop_process "$monitor_pid"
+monitor_pid=""
+stop_process "$janitor_pid"
+janitor_pid=""
+
+elapsed_seconds=$(($(date +%s) - started_at))
+
+if [[ -e "$failure_marker" ]]; then
+    exit 1
+fi
+
+if (( recorder_status != 0 )); then
+    echo "::error::Recorder exited with status $recorder_status."
+    exit "$recorder_status"
+fi
+
+if (( elapsed_seconds + 60 < duration_seconds )); then
+    echo "::error::Recorder exited before the requested duration."
+    exit 1
+fi
+
+if ! grep -Fq "Recording started for " log.log; then
+    echo "::error::The recorder never started writing the test channel."
+    exit 1
+fi
+
+if grep -Eq \
+    "Invalid NAL unit size|Error applying bitstream filters|ffmpeg failed for" \
+    log.log; then
+    echo "::error::FFmpeg reported corrupt input or a fatal failure."
+    exit 1
+fi
+
+if [[ -z "$(find_recording_files -size +0c -print -quit)" ]]; then
+    echo "::error::No non-empty recording segment remained after recording."
+    exit 1
+fi
+
+echo "Recording test completed after ${elapsed_seconds} seconds without a detected stall."


### PR DESCRIPTION
## Summary

- improve recording resilience when interrupted HLS data reaches FFmpeg
- add codec smoke-test coverage
- add a long-recording validation workflow and runner script

Fixes #71