### PR TITLE
Improve recovery from transient stream failures

### DIFF
--- a/chzzk_record.py
+++ b/chzzk_record.py
@@ -56,6 +56,14 @@ DEFAULT_RECORDING_SPLIT_MINUTES = 0
 MAX_RECORDING_SPLIT_MINUTES = 10080
 FFMPEG_FINALIZE_TIMEOUT_SECONDS = 60
 RECORDING_SHUTDOWN_TIMEOUT_SECONDS = 90
+STREAMLINK_SEGMENT_ATTEMPTS = 6
+STREAMLINK_SEGMENT_TIMEOUT_SECONDS = 15
+STREAMLINK_PLAYLIST_RELOAD_ATTEMPTS = 6
+STREAMLINK_OUTPUT_TIMEOUT_SECONDS = 90
+STREAMLINK_RECONNECT_BASE_DELAY_SECONDS = 2
+STREAMLINK_RECONNECT_MAX_DELAY_SECONDS = 30
+STREAMLINK_STABLE_RECORDING_SECONDS = 60
+STREAMLINK_SHUTDOWN_TIMEOUT_SECONDS = 20
 ENCODER_PROBE_TESTSRC = "testsrc2=size=640x480:rate=1"
 
 # Global console instance for Rich
@@ -429,6 +437,14 @@ def clamp_int(value: Any, default: int, min_value: int, max_value: int) -> int:
     except (TypeError, ValueError):
         return default
     return max(min_value, min(max_value, parsed))
+
+
+def streamlink_reconnect_delay(failure_count: int) -> int:
+    capped_failure_count = min(max(failure_count, 1), 5)
+    delay = STREAMLINK_RECONNECT_BASE_DELAY_SECONDS * (
+        2 ** (capped_failure_count - 1)
+    )
+    return min(delay, STREAMLINK_RECONNECT_MAX_DELAY_SECONDS)
 
 
 def normalize_bitrate(value: Any, default: str) -> str:
@@ -1953,6 +1969,7 @@ async def record_stream(
     active_attempt: Optional[RecordingProcessSandbox] = None
     runtime_av1_failures: Dict[str, str] = {}
     runtime_hevc_failures: Dict[str, str] = {}
+    consecutive_streamlink_failures = 0
 
     try:
         while not shutdown_event.is_set():
@@ -2065,6 +2082,8 @@ async def record_stream(
                         reserved_output_path = temp_output_path
 
                     active_attempt = RecordingProcessSandbox(channel_name, channel_id)
+                    streamlink_retry_delay: Optional[int] = None
+                    attempt_started_at = time.monotonic()
                     try:
                         # Start streamlink process
                         streamlink_cmd = [
@@ -2073,6 +2092,14 @@ async def record_stream(
                             stream_url,
                             "best",
                             "--hls-live-restart",
+                            "--stream-segment-attempts",
+                            str(STREAMLINK_SEGMENT_ATTEMPTS),
+                            "--stream-segment-timeout",
+                            str(STREAMLINK_SEGMENT_TIMEOUT_SECONDS),
+                            "--hls-playlist-reload-attempts",
+                            str(STREAMLINK_PLAYLIST_RELOAD_ATTEMPTS),
+                            "--stream-timeout",
+                            str(STREAMLINK_OUTPUT_TIMEOUT_SECONDS),
                             "--plugin-dirs",
                             str(PLUGIN_DIR_PATH),
                             "--stream-segment-threads",
@@ -2419,7 +2446,11 @@ async def record_stream(
                                 "cancelled" if task_cancelled else "shutdown"
                             )
                             stop_after_attempt = True
-                            await terminate_process(stream_process, "streamlink")
+                            await terminate_process(
+                                stream_process,
+                                "streamlink",
+                                timeout=STREAMLINK_SHUTDOWN_TIMEOUT_SECONDS,
+                            )
                             await drain_task(pipe_task, timeout=10)
                             if not await wait_for_task_completion(
                                 ffmpeg_wait_task,
@@ -2457,6 +2488,21 @@ async def record_stream(
 
                         ffmpeg_returncode = ffmpeg_process.returncode
                         stream_returncode = stream_process.returncode
+                        if (
+                            completed_by == "streamlink"
+                            and stream_returncode not in (0, None)
+                            and not shutdown_event.is_set()
+                        ):
+                            attempt_duration = time.monotonic() - attempt_started_at
+                            if attempt_duration >= STREAMLINK_STABLE_RECORDING_SECONDS:
+                                consecutive_streamlink_failures = 0
+                            consecutive_streamlink_failures += 1
+                            streamlink_retry_delay = streamlink_reconnect_delay(
+                                consecutive_streamlink_failures
+                            )
+                        elif completed_by != "shutdown":
+                            consecutive_streamlink_failures = 0
+
                         retry_with_software = False
                         if (
                             ffmpeg_returncode not in (0, None)
@@ -2586,6 +2632,24 @@ async def record_stream(
                                 with contextlib.suppress(OSError):
                                     if reserved_output_path.stat().st_size == 0:
                                         reserved_output_path.unlink()
+
+                    if streamlink_retry_delay is not None:
+                        logger.info(
+                            tr(
+                                "record.streamlink_reconnect",
+                                channel_name=channel_name,
+                                delay=streamlink_retry_delay,
+                                attempt=consecutive_streamlink_failures,
+                            )
+                        )
+                        try:
+                            await asyncio.wait_for(
+                                shutdown_event.wait(),
+                                timeout=streamlink_retry_delay,
+                            )
+                            break
+                        except asyncio.TimeoutError:
+                            continue
 
                 except asyncio.CancelledError:
                     logger.info(tr("record.task_cancelled", channel_name=channel_name))
@@ -2762,6 +2826,8 @@ async def manage_recording_tasks():
 
 
 def handle_shutdown():
+    if shutdown_event.is_set():
+        return
     logger.info(tr("record.shutdown_signal"))
     shutdown_event.set()
 

--- a/i18n.py
+++ b/i18n.py
@@ -430,6 +430,10 @@ TRANSLATIONS = {
             "{channel_name}의 streamlink가 실패했습니다. 원인은 위의 streamlink "
             "stderr 줄을 확인하세요."
         ),
+        "record.streamlink_reconnect": (
+            "{channel_name} 스트림에 {delay}초 후 다시 연결합니다 "
+            "(연속 실패 {attempt}회)."
+        ),
         "record.recording_stopped": "{channel_name} 녹화가 중지되었습니다.",
         "record.empty_segment_discarded": (
             "{channel_name}의 빈 녹화 세그먼트를 삭제했습니다: {path}"
@@ -835,6 +839,7 @@ TRANSLATIONS["en"].update({
     "record.stream_process_exited": "Stream recording process for {channel_name} exited with return code {returncode}.",
     "record.ffmpeg_failed": "ffmpeg failed for {channel_name}; see the ffmpeg stderr lines above for the root cause.",
     "record.streamlink_failed": "streamlink failed for {channel_name}; see the streamlink stderr lines above for the root cause.",
+    "record.streamlink_reconnect": "Reconnecting to {channel_name} in {delay} seconds (consecutive failure {attempt}).",
     "record.recording_stopped": "Recording stopped for {channel_name}.",
     "record.empty_segment_discarded": "Discarded empty recording segment for {channel_name}: {path}",
     "record.no_segments": "No recording segment files were created for {channel_name}.",
@@ -1303,6 +1308,7 @@ TRANSLATIONS["zh-CN"].update({
     "record.stream_process_exited": "{channel_name} 的流录制进程已退出，返回代码为 {returncode}。",
     "record.ffmpeg_failed": "{channel_name} 的 ffmpeg 失败；根本原因请查看上方 ffmpeg stderr 行。",
     "record.streamlink_failed": "{channel_name} 的 streamlink 失败；根本原因请查看上方 streamlink stderr 行。",
+    "record.streamlink_reconnect": "将在 {delay} 秒后重新连接 {channel_name}（连续失败 {attempt} 次）。",
     "record.recording_stopped": "{channel_name} 的录制已停止。",
     "record.empty_segment_discarded": "已删除 {channel_name} 的空录制分段：{path}",
     "record.no_segments": "{channel_name} 没有生成录制分段文件。",
@@ -1385,6 +1391,7 @@ TRANSLATIONS["zh-TW"].update({
     "record.stream_process_exited": "{channel_name} 的串流錄製程序已結束，返回碼為 {returncode}。",
     "record.ffmpeg_failed": "{channel_name} 的 ffmpeg 失敗；根本原因請查看上方 ffmpeg stderr 行。",
     "record.streamlink_failed": "{channel_name} 的 streamlink 失敗；根本原因請查看上方 streamlink stderr 行。",
+    "record.streamlink_reconnect": "將在 {delay} 秒後重新連線 {channel_name}（連續失敗 {attempt} 次）。",
     "record.recording_stopped": "{channel_name} 的錄製已停止。",
     "record.empty_segment_discarded": "已刪除 {channel_name} 的空錄製分段：{path}",
     "record.no_segments": "{channel_name} 沒有產生錄製分段檔案。",
@@ -1469,6 +1476,7 @@ TRANSLATIONS["ja"].update({
     "record.stream_process_exited": "{channel_name} のストリーム録画プロセスは戻りコード {returncode} で終了しました。",
     "record.ffmpeg_failed": "{channel_name} の ffmpeg が失敗しました。根本原因は上の ffmpeg stderr 行を確認してください。",
     "record.streamlink_failed": "{channel_name} の streamlink が失敗しました。根本原因は上の streamlink stderr 行を確認してください。",
+    "record.streamlink_reconnect": "{delay} 秒後に {channel_name} へ再接続します（連続失敗 {attempt} 回）。",
     "record.recording_stopped": "{channel_name} の録画を停止しました。",
     "record.empty_segment_discarded": "{channel_name} の空の録画セグメントを削除しました: {path}",
     "record.no_segments": "{channel_name} の録画セグメントファイルは作成されませんでした。",


### PR DESCRIPTION
## Summary

- retry HLS segment downloads and playlist reloads more aggressively during transient CDN failures
- reconnect unexpected Streamlink exits after 2 seconds with bounded exponential backoff instead of waiting for the 30-second channel poll interval
- make shutdown handling idempotent and give Streamlink 20 seconds to finalize before force-killing it
- add localized reconnect status messages for Korean, English, Simplified Chinese, Traditional Chinese, and Japanese

## Motivation

A five-hour recording log showed repeated HLS sequence gaps, three CDN 504 responses, and a Streamlink read timeout. The recorder recovered, but only after the normal 30-second channel polling delay. The final timed shutdown was also logged twice and force-killed Streamlink after five seconds.

## Verification

- `python -m py_compile chzzk_record.py i18n.py settings.py plugin/chzzk.py`
- Streamlink 8.4.0 accepted the new retry and timeout arguments and resolved the bundled CHZZK plugin
- reconnect backoff verified as `2, 4, 8, 16, 30, 30` seconds
- reconnect message formatting verified for all supported languages
- duplicate shutdown calls verified to emit one shutdown log entry
- `git diff --check`

## Follow-up

The manual long-recording workflow should be run before marking this PR ready for review.